### PR TITLE
Suggestion: Removing the border around the image

### DIFF
--- a/templates/XCard.html
+++ b/templates/XCard.html
@@ -1,6 +1,6 @@
 <body>
     {{#if imageToggle}}
-        <img style="display:block; margin-left:auto; margin-right:auto" src="{{ imagePath }}" width="{{ imageWidth }}" height="{{ imageHeight }}" />
+        <img style="display:block; margin-left:auto; margin-right:auto; border:none" src="{{ imagePath }}" width="{{ imageWidth }}" height="{{ imageHeight }}" />
     {{/if}}
 
     {{#unless imageToggle}}


### PR DESCRIPTION
The border is a bit distracting and thus annoying (for me at least) when using images with transparency on the sides. This would remove the border. In most cases this should only be noticeable on images with transparency on the sides. On images without transparency it should hardly be noticeable.